### PR TITLE
feat: add theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
   <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap" rel="stylesheet">
   <style>
     :root {
+      --bg:#FFF7FA; --text:#4A4A4A; --accent:#FF8FB1; --muted:#FFE5EC; --muted-2:#FFF1F5; --active:#FDCEDF;
+    }
+    html[data-theme="neutral"] {
       --bg:#FDFBF8; --text:#4A4A4A; --accent:#8C7D6F; --muted:#EFEBE7; --muted-2:#F7F4F1; --active:#D6C3B4;
     }
     html,body { background:var(--bg); color:var(--text); font-family: sans-serif; }
@@ -39,6 +42,7 @@
             <option value="en">English</option>
             <option value="ceb">Bisayâ (Cebuano)</option>
           </select>
+          <button id="theme-toggle" class="border rounded p-2">Theme</button>
         </div>
       </div>
       <div class="flex items-center gap-3 mb-4">

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,12 @@
  * and a language selector for basic UI labels (English and Bisayâ/Cebuano).
  */
 
+// Read stored theme early and apply before rendering
+const savedTheme = localStorage.getItem('theme');
+if (savedTheme === 'neutral') {
+  document.documentElement.setAttribute('data-theme', 'neutral');
+}
+
 // Define the rubric structures: titles, criteria, point ranges and notes.
 const rubricData = {
   esl: {
@@ -124,7 +130,8 @@ const state = {
   currentRubric: 'esl',
   isTeacherView: false,
   scores: {},
-  lang: 'en'
+  lang: 'en',
+  theme: savedTheme || 'pastel'
 };
 
 // Cache DOM elements
@@ -146,6 +153,7 @@ const dom = {
   totalLabel: document.getElementById('total-score-label'),
   notesLabel: document.getElementById('notes-toggle-label'),
   langSelect: document.getElementById('lang-select'),
+  themeToggle: document.getElementById('theme-toggle'),
   notes: {
     toggle: document.getElementById('notes-toggle'),
     content: document.getElementById('notes-content'),
@@ -167,6 +175,18 @@ function applyTranslations() {
   dom.notesLabel.textContent = t.notes;
   // Update document lang attribute
   document.documentElement.lang = state.lang;
+}
+
+// Apply a theme and persist it
+function setTheme(theme) {
+  if (theme === 'neutral') {
+    document.documentElement.setAttribute('data-theme', 'neutral');
+  } else {
+    document.documentElement.removeAttribute('data-theme');
+    theme = 'pastel';
+  }
+  state.theme = theme;
+  localStorage.setItem('theme', theme);
 }
 
 // Calculate a representative score for a given level of a criterion
@@ -337,6 +357,12 @@ function init() {
     state.lang = e.target.value;
     applyTranslations();
   });
+  // Theme toggle
+  dom.themeToggle.addEventListener('click', () => {
+    const newTheme = state.theme === 'pastel' ? 'neutral' : 'pastel';
+    setTheme(newTheme);
+  });
+  setTheme(state.theme);
   // Initial setup
   resetScores();
   renderRubric();


### PR DESCRIPTION
## Summary
- replace root color variables with pastel palette and add neutral theme variant
- add theme switch button in header
- implement theme persistence and toggling via localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e4b8ae60832894c5d6cf70d190cd