### PR TITLE
Use violet palette for bar chart

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -198,8 +198,8 @@ function initChart() {
       datasets: [{
         label: 'Points Awarded',
         data: data.criteria.map(() => 0),
-        backgroundColor: '#D6C3B4',
-        borderColor: '#8C7D6F',
+        backgroundColor: '#A78BFA',
+        borderColor: '#6B5FD3',
         borderWidth: 1
       }]
     },
@@ -225,6 +225,8 @@ function updateChart() {
   const data = rubricData[state.currentRubric];
   scoreChart.data.labels = data.criteria.map(c => c.name);
   scoreChart.data.datasets[0].data = data.criteria.map(c => state.scores[c.name] || 0);
+  scoreChart.data.datasets[0].backgroundColor = '#A78BFA';
+  scoreChart.data.datasets[0].borderColor = '#6B5FD3';
   scoreChart.update();
 }
 


### PR DESCRIPTION
## Summary
- switch chart bar colors to a violet background and blue border
- update `updateChart` to apply the new colors when refreshing

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e4bc7404832889dc254894830687