### PR TITLE
feat: add PDF export button

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,16 @@
     .toggle-bg:after { content:''; position:absolute; top:2px; left:2px; background:white; width:20px; height:20px; border-radius:9999px; transition: transform .3s; }
     input:checked + .toggle-bg:after { transform: translateX(100%); }
     input:checked + .toggle-bg { background:var(--accent); }
+    @media print {
+      nav,
+      #view-toggle,
+      #student-view-label,
+      #teacher-view-label,
+      #notes-toggle,
+      #lang-select,
+      #export-pdf { display: none; }
+      body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    }
   </style>
 </head>
 <body class="antialiased">
@@ -39,6 +49,7 @@
             <option value="en">English</option>
             <option value="ceb">Bisayâ (Cebuano)</option>
           </select>
+          <button id="export-pdf" class="border rounded p-2">Export PDF</button>
         </div>
       </div>
       <div class="flex items-center gap-3 mb-4">

--- a/src/app.js
+++ b/src/app.js
@@ -107,7 +107,8 @@ const translations = {
     teacher: "Teacher View",
     summary: "Grading Summary",
     total: "Total Score:",
-    notes: "Scoring Notes & Rationale"
+    notes: "Scoring Notes & Rationale",
+    exportPdf: "Export PDF"
   },
   ceb: {
     nav: { esl: "ESL Rubriks", general: "General Rubriks" },
@@ -115,7 +116,8 @@ const translations = {
     teacher: "Tan‑aw sa Magtutudlo",
     summary: "Summaryo sa Paggrado",
     total: "Kinatibuk-ang Iskor:",
-    notes: "Mga Notas ug Rasón sa Paggrado"
+    notes: "Mga Notas ug Rasón sa Paggrado",
+    exportPdf: "I-export ang PDF"
   }
 };
 
@@ -146,6 +148,7 @@ const dom = {
   totalLabel: document.getElementById('total-score-label'),
   notesLabel: document.getElementById('notes-toggle-label'),
   langSelect: document.getElementById('lang-select'),
+  exportPdfBtn: document.getElementById('export-pdf'),
   notes: {
     toggle: document.getElementById('notes-toggle'),
     content: document.getElementById('notes-content'),
@@ -165,6 +168,7 @@ function applyTranslations() {
   dom.summaryLabel.textContent = t.summary;
   dom.totalLabel.textContent = t.total;
   dom.notesLabel.textContent = t.notes;
+  dom.exportPdfBtn.textContent = t.exportPdf;
   // Update document lang attribute
   document.documentElement.lang = state.lang;
 }
@@ -336,6 +340,10 @@ function init() {
   dom.langSelect.addEventListener('change', (e) => {
     state.lang = e.target.value;
     applyTranslations();
+  });
+  // Export PDF
+  dom.exportPdfBtn.addEventListener('click', () => {
+    window.print();
   });
   // Initial setup
   resetScores();


### PR DESCRIPTION
## Summary
- add Export PDF button to header
- add print-specific stylesheet and translation support
- hook button to window.print

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e4d3f880832897a61cc642d52014