### PR TITLE
feat: import rubric JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,8 @@
     <nav class="flex justify-center mb-6 border-b-2 border-[var(--muted)] pb-2" role="tablist">
       <button id="nav-esl" class="tab-active text-lg font-semibold py-3 px-8 rounded-t-lg" role="tab" aria-selected="true" data-rubric="esl">ESL Rubric</button>
       <button id="nav-general" class="tab-inactive text-lg font-semibold py-3 px-8 rounded-t-lg" role="tab" aria-selected="false" data-rubric="general">General Rubric</button>
+      <button id="import-rubric-btn" class="tab-inactive text-lg font-semibold py-3 px-8 rounded-t-lg ml-4" type="button">Import rubric JSON</button>
+      <input type="file" id="import-rubric-input" accept="application/json" class="hidden" />
     </nav>
     <main>
       <div class="flex justify-center items-center mb-6 gap-4">

--- a/src/app.js
+++ b/src/app.js
@@ -146,6 +146,8 @@ const dom = {
   totalLabel: document.getElementById('total-score-label'),
   notesLabel: document.getElementById('notes-toggle-label'),
   langSelect: document.getElementById('lang-select'),
+  importButton: document.getElementById('import-rubric-btn'),
+  importInput: document.getElementById('import-rubric-input'),
   notes: {
     toggle: document.getElementById('notes-toggle'),
     content: document.getElementById('notes-content'),
@@ -294,6 +296,30 @@ function resetScores() {
   crits.forEach(c => { state.scores[c.name] = 0; });
 }
 
+// Import rubric JSON and replace current rubric data
+function handleImport(e) {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = evt => {
+    try {
+      const imported = JSON.parse(evt.target.result);
+      rubricData[state.currentRubric] = imported;
+      resetScores();
+      renderRubric();
+      updateTotalScore();
+      if (scoreChart) scoreChart.destroy();
+      initChart();
+      updateChart();
+    } catch (err) {
+      console.error('Failed to import rubric JSON', err);
+      alert('Invalid rubric JSON file.');
+    }
+  };
+  reader.readAsText(file);
+  e.target.value = '';
+}
+
 // Handle navigation button clicks
 function handleNavClick(e) {
   const rubric = e.target.getAttribute('data-rubric');
@@ -319,6 +345,9 @@ function init() {
   // Event listeners for nav buttons
   dom.nav.esl.addEventListener('click', handleNavClick);
   dom.nav.general.addEventListener('click', handleNavClick);
+  // Import rubric JSON
+  dom.importButton.addEventListener('click', () => dom.importInput.click());
+  dom.importInput.addEventListener('change', handleImport);
   // Student/Teacher toggle
   dom.viewToggle.addEventListener('change', (e) => {
     state.isTeacherView = e.target.checked;


### PR DESCRIPTION
## Summary
- add navigation button and file input to import rubric JSON
- parse uploaded rubric JSON and replace current rubric data
- re-render rubric, reset scores, and refresh chart after import

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e4fb15dc8328a1d0b5376e579921