### PR TITLE
Add reset and copy grade controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,10 @@
       </section>
       <section id="teacher-tools" class="hidden mt-8">
         <h3 id="grading-summary-label" class="text-2xl font-bold text-[var(--accent)] mb-4 text-center">Grading Summary</h3>
+        <div class="flex justify-end mb-4 gap-4">
+          <button id="reset-scores" class="px-4 py-2 bg-[var(--muted)] rounded">Reset</button>
+          <button id="copy-grades" class="px-4 py-2 bg-[var(--accent)] text-white rounded">Copy Grades</button>
+        </div>
         <div class="grid md:grid-cols-2 gap-8">
           <div id="scoring-summary" class="bg-white rounded-lg shadow p-6">
             <div class="flex justify-between items-baseline mb-4">

--- a/src/app.js
+++ b/src/app.js
@@ -139,6 +139,8 @@ const dom = {
   rubricTableWrapper: document.getElementById('rubric-table-wrapper'),
   teacherTools: document.getElementById('teacher-tools'),
   totalScore: document.getElementById('total-score'),
+  resetBtn: document.getElementById('reset-scores'),
+  copyBtn: document.getElementById('copy-grades'),
   // labels to translate
   studentLabel: document.getElementById('student-view-label'),
   teacherLabel: document.getElementById('teacher-view-label'),
@@ -294,6 +296,20 @@ function resetScores() {
   crits.forEach(c => { state.scores[c.name] = 0; });
 }
 
+// Copy total and per-criterion scores to the clipboard
+function copyGrades() {
+  const rubric = rubricData[state.currentRubric];
+  const lines = [`Total: ${dom.totalScore.textContent}`];
+  rubric.criteria.forEach(c => {
+    const score = state.scores[c.name] || 0;
+    lines.push(`${c.name}: ${score}`);
+  });
+  const text = lines.join('\n');
+  navigator.clipboard.writeText(text).catch(err => {
+    console.error('Failed to copy grades:', err);
+  });
+}
+
 // Handle navigation button clicks
 function handleNavClick(e) {
   const rubric = e.target.getAttribute('data-rubric');
@@ -337,6 +353,13 @@ function init() {
     state.lang = e.target.value;
     applyTranslations();
   });
+  // Reset and copy buttons
+  dom.resetBtn.addEventListener('click', () => {
+    resetScores();
+    renderRubric();
+    updateTotalScore();
+  });
+  dom.copyBtn.addEventListener('click', copyGrades);
   // Initial setup
   resetScores();
   renderRubric();


### PR DESCRIPTION
## Summary
- Add Reset and Copy Grades buttons to teacher tools
- Implement clipboard copying of total and criterion scores
- Wire up reset and copy buttons in application init

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check src/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6e5007ca88328b22cb245a4e626d1