### PR TITLE
Add printable stylesheet and PDF export

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <!-- Calligraphic font for signature -->
   <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="print.css" media="print">
   <style>
     :root {
       --bg:#FDFBF8; --text:#4A4A4A; --accent:#8C7D6F; --muted:#EFEBE7; --muted-2:#F7F4F1; --active:#D6C3B4;
@@ -65,9 +66,12 @@
         <p id="rubric-subtitle" class="text-md text-gray-500 mb-4"></p>
         <div id="rubric-table-wrapper"></div>
       </section>
-      <section id="teacher-tools" class="hidden mt-8">
-        <h3 id="grading-summary-label" class="text-2xl font-bold text-[var(--accent)] mb-4 text-center">Grading Summary</h3>
-        <div class="grid md:grid-cols-2 gap-8">
+        <section id="teacher-tools" class="hidden mt-8">
+          <div class="flex justify-end mb-4">
+            <button id="export-pdf" class="no-print px-4 py-2 bg-[var(--accent)] text-white rounded">Export PDF</button>
+          </div>
+          <h3 id="grading-summary-label" class="text-2xl font-bold text-[var(--accent)] mb-4 text-center">Grading Summary</h3>
+          <div class="grid md:grid-cols-2 gap-8">
           <div id="scoring-summary" class="bg-white rounded-lg shadow p-6">
             <div class="flex justify-between items-baseline mb-4">
               <h4 id="total-score-label" class="text-xl font-semibold">Total Score:</h4>
@@ -101,6 +105,8 @@
       </footer>
     </main>
   </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="src/app.js"></script>
-</body>
-</html>
+  </body>
+  </html>

--- a/print.css
+++ b/print.css
@@ -1,0 +1,49 @@
+/* Print styles for rubric and summary */
+@page {
+  size: A4;
+  margin: 20mm;
+}
+
+body {
+  background: #fff;
+  color: #000;
+  font-size: 12pt;
+}
+
+nav,
+#view-toggle,
+#student-view-label,
+#teacher-view-label,
+.no-print {
+  display: none !important;
+}
+
+#teacher-tools {
+  display: block !important;
+}
+
+#notes-toggle {
+  display: none !important;
+}
+
+#notes-content {
+  display: block !important;
+}
+
+#rubric-container,
+#teacher-tools,
+#notes-container {
+  page-break-inside: avoid;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid #ccc;
+  padding: 4px;
+}
+

--- a/src/app.js
+++ b/src/app.js
@@ -137,10 +137,11 @@ const dom = {
   rubricTitle: document.getElementById('rubric-title'),
   rubricSubtitle: document.getElementById('rubric-subtitle'),
   rubricTableWrapper: document.getElementById('rubric-table-wrapper'),
-  teacherTools: document.getElementById('teacher-tools'),
-  totalScore: document.getElementById('total-score'),
-  // labels to translate
-  studentLabel: document.getElementById('student-view-label'),
+    teacherTools: document.getElementById('teacher-tools'),
+    totalScore: document.getElementById('total-score'),
+    exportBtn: document.getElementById('export-pdf'),
+    // labels to translate
+    studentLabel: document.getElementById('student-view-label'),
   teacherLabel: document.getElementById('teacher-view-label'),
   summaryLabel: document.getElementById('grading-summary-label'),
   totalLabel: document.getElementById('total-score-label'),
@@ -336,6 +337,18 @@ function init() {
   dom.langSelect.addEventListener('change', (e) => {
     state.lang = e.target.value;
     applyTranslations();
+  });
+  // Export PDF
+  dom.exportBtn.addEventListener('click', () => {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF('p', 'pt', 'a4');
+    doc.html(document.getElementById('rubric-container'), {
+      callback: function (doc) {
+        doc.save('rubric.pdf');
+      },
+      margin: [20, 20, 20, 20],
+      html2canvas: { scale: 0.75 }
+    });
   });
   // Initial setup
   resetScores();


### PR DESCRIPTION
## Summary
- add print.css with A4 formatting and hide interactive controls when printing
- link print.css and jspdf/html2canvas CDN scripts; provide Export PDF button
- implement PDF export of rubric section using jsPDF

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a6e5041bf08328bd69c8068d1ea0b2