### PR TITLE
feat: add text size toggle and focus outlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
     .toggle-bg:after { content:''; position:absolute; top:2px; left:2px; background:white; width:20px; height:20px; border-radius:9999px; transition: transform .3s; }
     input:checked + .toggle-bg:after { transform: translateX(100%); }
     input:checked + .toggle-bg { background:var(--accent); }
+    button:focus-visible, .score-cell:focus-visible, select:focus-visible, input:focus-visible {
+      outline:2px solid #2563EB;
+      outline-offset:2px;
+    }
   </style>
 </head>
 <body class="antialiased">
@@ -39,6 +43,7 @@
             <option value="en">English</option>
             <option value="ceb">Bisayâ (Cebuano)</option>
           </select>
+          <button id="text-size-toggle" class="border rounded p-2" aria-pressed="false">Text size</button>
         </div>
       </div>
       <div class="flex items-center gap-3 mb-4">

--- a/src/app.js
+++ b/src/app.js
@@ -124,7 +124,8 @@ const state = {
   currentRubric: 'esl',
   isTeacherView: false,
   scores: {},
-  lang: 'en'
+  lang: 'en',
+  largeText: false
 };
 
 // Cache DOM elements
@@ -134,6 +135,7 @@ const dom = {
     general: document.getElementById('nav-general')
   },
   viewToggle: document.getElementById('view-toggle'),
+  textSizeToggle: document.getElementById('text-size-toggle'),
   rubricTitle: document.getElementById('rubric-title'),
   rubricSubtitle: document.getElementById('rubric-subtitle'),
   rubricTableWrapper: document.getElementById('rubric-table-wrapper'),
@@ -336,6 +338,12 @@ function init() {
   dom.langSelect.addEventListener('change', (e) => {
     state.lang = e.target.value;
     applyTranslations();
+  });
+  // Text size toggle
+  dom.textSizeToggle.addEventListener('click', () => {
+    state.largeText = !state.largeText;
+    dom.textSizeToggle.setAttribute('aria-pressed', state.largeText);
+    document.getElementById('app').classList.toggle('text-lg', state.largeText);
   });
   // Initial setup
   resetScores();


### PR DESCRIPTION
## Summary
- add keyboard-accessible text size toggle to header
- highlight interactive elements with visible focus outlines
- ensure rubric cells remain keyboard navigable with tabindex and aria-pressed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e4c7ef9883288bfd98bdeed876ba