### PR TITLE
Show copy confirmation and handle errors

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -324,9 +324,18 @@ function copyGrades() {
     lines.push(`${c.name}: ${score}`);
   });
   const text = lines.join('\n');
-  navigator.clipboard.writeText(text).catch(err => {
-    console.error('Failed to copy grades:', err);
-  });
+  navigator.clipboard.writeText(text)
+    .then(() => {
+      const originalLabel = dom.copyBtn.textContent;
+      dom.copyBtn.textContent = 'Copied!';
+      setTimeout(() => {
+        dom.copyBtn.textContent = originalLabel;
+      }, 2000);
+    })
+    .catch(err => {
+      console.error('Failed to copy grades:', err);
+      alert('Failed to copy grades. Please try again.');
+    });
 }
 
 // Import rubric JSON and replace current rubric data


### PR DESCRIPTION
## Summary
- Confirm successful grade copy by temporarily changing the "Copy Grades" button text
- Alert the user if copying to the clipboard fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ec05eb588328a65a13689e8f7898