### PR TITLE
Move inline styles to external stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,58 +10,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <!-- Calligraphic font for signature -->
   <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="src/styles.css">
   <link rel="stylesheet" href="print.css" media="print">
-  <style>
-      :root {
-        --bg:#FDFBF8;
-        --text:#4A4A4A;
-        --accent:#8C7D6F;
-        --muted:#EFEBE7;
-        --muted-2:#F7F4F1;
-        --active:#D6C3B4;
-        --text-muted:#6B7280;
-        --border:#E5E7EB;
-        --panel:#FFFFFF;
-      }
-      html[data-theme="pastel"] {
-        --bg:#FFF7F8;
-        --text:#5D576B;
-        --accent:#A05C7B;
-        --muted:#FFE5E9;
-        --muted-2:#FFF0F3;
-        --active:#F2B5D4;
-        --text-muted:#7A728B;
-        --border:#FAD1DC;
-        --panel:#FFFFFF;
-      }
-      html[data-theme="neutral"] {
-        --bg:#FDFBF8;
-        --text:#4A4A4A;
-        --accent:#8C7D6F;
-        --muted:#EFEBE7;
-        --muted-2:#F7F4F1;
-        --active:#D6C3B4;
-        --text-muted:#6B7280;
-        --border:#E5E7EB;
-        --panel:#FFFFFF;
-      }
-      html,body { background:var(--bg); color:var(--text); font-family: sans-serif; }
-      .signature { font-family:'Great Vibes', cursive; }
-      .tab-active { background:var(--active); color:var(--bg); }
-      .tab-inactive { background:var(--muted); color:var(--text); }
-      .table-header { background:var(--muted); }
-      .criterion-cell { background:var(--muted-2); }
-      .score-cell { cursor:pointer; transition: background-color .2s; }
-      .score-cell:hover { background:#E3D9CF; }
-      .score-cell.selected { background:var(--active); color:white; font-weight:bold; }
-      .toggle-bg:after { content:''; position:absolute; top:2px; left:2px; background:white; width:20px; height:20px; border-radius:9999px; transition: transform .3s; }
-      input:checked + .toggle-bg:after { transform: translateX(100%); }
-      input:checked + .toggle-bg { background:var(--accent); }
-      button:focus-visible, .score-cell:focus-visible, select:focus-visible, input:focus-visible {
-        outline:2px solid #2563EB;
-        outline-offset:2px;
-      }
-  </style>
 </head>
 <body class="antialiased">
   <div id="app" class="container mx-auto px-4 py-8 max-w-7xl">

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,49 @@
+:root {
+  --bg:#FDFBF8;
+  --text:#4A4A4A;
+  --accent:#8C7D6F;
+  --muted:#EFEBE7;
+  --muted-2:#F7F4F1;
+  --active:#D6C3B4;
+  --text-muted:#6B7280;
+  --border:#E5E7EB;
+  --panel:#FFFFFF;
+}
+html[data-theme="pastel"] {
+  --bg:#FFF7F8;
+  --text:#5D576B;
+  --accent:#A05C7B;
+  --muted:#FFE5E9;
+  --muted-2:#FFF0F3;
+  --active:#F2B5D4;
+  --text-muted:#7A728B;
+  --border:#FAD1DC;
+  --panel:#FFFFFF;
+}
+html[data-theme="neutral"] {
+  --bg:#FDFBF8;
+  --text:#4A4A4A;
+  --accent:#8C7D6F;
+  --muted:#EFEBE7;
+  --muted-2:#F7F4F1;
+  --active:#D6C3B4;
+  --text-muted:#6B7280;
+  --border:#E5E7EB;
+  --panel:#FFFFFF;
+}
+html,body { background:var(--bg); color:var(--text); font-family: sans-serif; }
+.signature { font-family:'Great Vibes', cursive; }
+.tab-active { background:var(--active); color:var(--bg); }
+.tab-inactive { background:var(--muted); color:var(--text); }
+.table-header { background:var(--muted); }
+.criterion-cell { background:var(--muted-2); }
+.score-cell { cursor:pointer; transition: background-color .2s; }
+.score-cell:hover { background:#E3D9CF; }
+.score-cell.selected { background:var(--active); color:white; font-weight:bold; }
+.toggle-bg:after { content:''; position:absolute; top:2px; left:2px; background:white; width:20px; height:20px; border-radius:9999px; transition: transform .3s; }
+input:checked + .toggle-bg:after { transform: translateX(100%); }
+input:checked + .toggle-bg { background:var(--accent); }
+button:focus-visible, .score-cell:focus-visible, select:focus-visible, input:focus-visible {
+  outline:2px solid #2563EB;
+  outline-offset:2px;
+}


### PR DESCRIPTION
## Summary
- Extract inline `<style>` block into new `src/styles.css`
- Link external stylesheet from `index.html` and remove inline styles
- Confirm theme switching still reads CSS variables

## Testing
- `node <script>`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ec079ca883288cf95aac2f58b698