### PR TITLE
Add schema validation and note sanitization for rubric imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@
   </div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.4.3/purify.min.js"></script>
   <script src="src/app.js"></script>
 </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -161,6 +161,45 @@ const dom = {
   }
 };
 
+// Schema definition for imported rubric objects
+const rubricSchema = {
+  criteriaRequiredKeys: ['name', 'weight', 'levels'],
+  levelCount: 4,
+  rangeCount: 4,
+  pointRangeSets: 2
+};
+
+// Validate that an imported rubric matches the schema
+function validateRubric(data) {
+  if (!data || typeof data !== 'object') return false;
+  if (!Array.isArray(data.criteria) || !Array.isArray(data.pointRanges) || typeof data.notes !== 'string') {
+    return false;
+  }
+  if (data.pointRanges.length !== rubricSchema.pointRangeSets) return false;
+  for (const criterion of data.criteria) {
+    if (
+      typeof criterion.name !== 'string' ||
+      typeof criterion.weight !== 'number' ||
+      !Array.isArray(criterion.levels) ||
+      criterion.levels.length !== rubricSchema.levelCount ||
+      !criterion.levels.every(l => typeof l === 'string')
+    ) {
+      return false;
+    }
+    for (const range of data.pointRanges) {
+      const arr = range[criterion.name];
+      if (
+        !Array.isArray(arr) ||
+        arr.length !== rubricSchema.rangeCount ||
+        !arr.every(n => typeof n === 'number')
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 // Apply translations for the current language
 function applyTranslations() {
   const t = translations[state.lang] || translations.en;
@@ -254,7 +293,7 @@ function renderRubric() {
   const data = rubricData[state.currentRubric];
   dom.rubricTitle.textContent = data.title;
   dom.rubricSubtitle.textContent = data.subtitle;
-  dom.notes.content.innerHTML = data.notes;
+  dom.notes.content.innerHTML = DOMPurify.sanitize(data.notes);
   const isTeacher = state.isTeacherView;
   let html = '<table class="w-full border-collapse">';
   // Header
@@ -337,6 +376,10 @@ function handleImport(e) {
   reader.onload = evt => {
     try {
       const imported = JSON.parse(evt.target.result);
+      if (!validateRubric(imported)) {
+        throw new Error('Schema mismatch');
+      }
+      imported.notes = DOMPurify.sanitize(imported.notes || '');
       rubricData[state.currentRubric] = imported;
       resetScores();
       renderRubric();


### PR DESCRIPTION
## Summary
- define schema and validation for imported rubric objects
- sanitize imported rubric notes before rendering
- load DOMPurify from CDN

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ec0140388328b829dd7174a6c034