### PR TITLE
Use weighted scale for rubric scoring

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -11,9 +11,9 @@ export const state = {
 
 export function calculateScore(criterionName, levelIndex) {
   const rubric = rubricData[state.currentRubric];
-  const min = rubric.pointRanges[0][criterionName][levelIndex];
-  const max = rubric.pointRanges[1][criterionName][levelIndex];
-  return Math.round((min + max) / 2);
+  const criterion = rubric.criteria.find(c => c.name === criterionName);
+  const scale = [0, 0.6, 0.8, 1.0];
+  return Math.round((criterion?.weight || 0) * scale[levelIndex]);
 }
 
 export function resetScores() {


### PR DESCRIPTION
## Summary
- replace range-based score calculation with scaled weight lookup
- compute per-criterion scores using [0,0.6,0.8,1.0] scale

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --input-type=module - <<'NODE'
  global.localStorage = { getItem: () => null };
  const { state, calculateScore } = await import('./src/state.js');
  const { rubricData } = await import('./src/rubric-data.js');
  state.currentRubric = 'esl';
  const total = rubricData.esl.criteria.reduce((sum, c) => sum + calculateScore(c.name, 3), 0);
  console.log('ESL total', total);
  state.currentRubric = 'general';
  const totalG = rubricData.general.criteria.reduce((sum, c) => sum + calculateScore(c.name, 3), 0);
  console.log('General total', totalG);
  NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a7019f2ec48328b27fe53ab48b8d1f